### PR TITLE
Cheating prevention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,129 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/engine/OthelloEngine.py
+++ b/engine/OthelloEngine.py
@@ -1,6 +1,7 @@
 import time
 import json
 import sys
+import copy
 
 class GameEngine:
    # white_team_file will be the file name of the white team's AI file
@@ -32,6 +33,10 @@ class GameEngine:
 
       # Initiaize white_team_file and black_team_file's AIs
       # (might want to refer to http://www.blog.pythonlibrary.org/2012/07/31/advanced-python-how-to-dynamically-load-modules-or-classes/)
+      if white_team_file.endswith('.py'):
+         white_team_file = white_team_file[:-3]
+      if black_team_file.endswith('.py'):
+         black_team_file = black_team_file[:-3]
       w_module = __import__(white_team_file)
       b_module = __import__(black_team_file)
       self.white_team = getattr(w_module, "Othello_AI")('W', n, time_limit)
@@ -86,7 +91,7 @@ class GameEngine:
    def record_turn(self, team):
       try:
          start = time.time()
-         move = team.get_move(self.game_state)
+         move = team.get_move(copy.deepcopy(self.game_state))
          turnTime = time.time() - start
 
          if turnTime > self.time_limit:
@@ -116,6 +121,10 @@ class GameEngine:
       #    there are no legal moves for this player/
       # You will want to use get_all_moves
       # return True if the move is legal, and False otherwise
+      current_team = 'W' if self.turn_number % 2 == 1 else 'B'
+      if (move[0] != current_team):
+          return False
+      
       vMoves = get_all_moves(self.game_state, move[0])
       if move[1] is None:
          if len(vMoves) is 0:


### PR DESCRIPTION
This PR fixes two ways that a bot would have been able to cheat:
 * A bot could cheat by making a move for the other player (which is unlikely to be good for them, but is cheating nonetheless)
 * A bot could cheat by modifying the engine's board_state which was previously passed by reference

Another enhancement is that the engine will now accept files with the ".py" suffix for the bots as well as without for ease of use.

Finally, a .gitignore was added to prevent various python files from being added to this repo